### PR TITLE
fix: markdown link to INSTALL.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Linux distributions.
 - One-step Automated Install:
   #### `curl -sSL https://github.com/leiweibau/Pi.Alert/raw/main/install/pialert_install.sh | bash`
 
-- [Installation Guide (step by step)](docs/INSTALL.
+- [Installation Guide (step by step)](docs/INSTALL.md)
 
 
 # Uninstall process


### PR DESCRIPTION
In the README.md the link to INSTALL.md is broken. This PR corrects the incorrect markdown at this point.