### PR TITLE
iab is no longer needed and was depreciated in arp-scan 1.10

### DIFF
--- a/back/pialert.py
+++ b/back/pialert.py
@@ -352,8 +352,8 @@ def update_devices_MAC_vendors (pArg = ''):
     print ('Update HW Vendors')
     print ('    Timestamp:', startTime )
 
-    # Update vendors DB (iab oui)
-    print ('\nUpdating vendors DB (iab & oui)...')
+    # Update vendors DB (oui)
+    print ('\nUpdating vendors DB...')
     update_args = ['sh', PIALERT_BACK_PATH + '/update_vendors.sh', pArg]
     update_output = subprocess.check_output (update_args)
 

--- a/back/update_vendors.sh
+++ b/back/update_vendors.sh
@@ -24,9 +24,6 @@ sudo mkdir -p 2_backup
 sudo cp *.txt 2_backup
 sudo cp *.csv 2_backup
 
-sudo curl $1 -# -O https://standards-oui.ieee.org/iab/iab.csv
-sudo curl $1 -# -O https://standards-oui.ieee.org/iab/iab.txt
-
 sudo curl $1 -# -O https://standards-oui.ieee.org/oui28/mam.csv
 sudo curl $1 -# -O https://standards-oui.ieee.org/oui28/mam.txt
 
@@ -46,7 +43,6 @@ sudo mkdir -p 2_backup
 sudo cp *.txt 2_backup
 
 # Update from /usb/lib/ieee-data
-sudo get-iab -v
 sudo get-oui -v
 
 # Update from ieee website


### PR DESCRIPTION
get-oui is now used to fetch all of the Ethernet MAC-Vendor
mappings from the various IEEE registries.