### PR TITLE
Added support for Mikrotik routeros DHCP server and Unifi client list

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ a notification can be sent.
   - **Fritzbox**. This method is optional. If you use a Fritzbox (a router from the company "AVM"), 
         it is possible to perform a query of the active hosts. This also 
         includes hosts of the guest WLAN and Powerline devices from "AVM".
+  - **Mikrotik**. This method is optional. If you use Mikrotik RouterBoard as DHCP server,
+        it is possible to read DHCP leases.
+  - **UniFi**. This method is optional. If you use UniFi controller,
+        it is possible to read clients (Client Devices)
   - **Web service monitoring**. This method is optional. An HTTP request is 
         sent and the web server's response is processed. If self signed 
         certificates are used, no validation of the certificate is performed.

--- a/back/pialert.py
+++ b/back/pialert.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
-from fritzconnection.lib.fritzhosts import FritzHosts
 from mac_vendor_lookup import MacLookup
 from time import sleep, time, strftime
 from base64 import b64encode
@@ -467,6 +466,16 @@ def scan_network ():
     openDB()
     print_log ('Fritzbox copy starts...')
     read_fritzbox_active_hosts()
+    # Mikrotik method
+    print ('    Mikrotik Method...')
+    openDB()
+    print_log ('Mikrotik copy starts...')
+    read_mikrotik_leases()
+    # UniFi method
+    print ('    UniFi Method...')
+    openDB()
+    print_log ('UniFi copy starts...')
+    read_unifi_clients()
     # Load current scan data 1/2
     print ('\nProcessing scan results...')
     # Load current scan data 2/2
@@ -667,6 +676,8 @@ def read_fritzbox_active_hosts ():
     if not FRITZBOX_ACTIVE :
         return
 
+    from fritzconnection.lib.fritzhosts import FritzHosts
+
     # copy Fritzbox Network list
     fh = FritzHosts(address=FRITZBOX_IP, user=FRITZBOX_USER, password=FRITZBOX_PASS)
     hosts = fh.get_hosts_info()
@@ -683,6 +694,83 @@ def read_fritzbox_active_hosts ():
             
             sql.execute ("INSERT INTO Fritzbox_Network (FB_MAC, FB_IP, FB_Name, FB_Vendor) "+
                          "VALUES (?, ?, ?, ?) ", (mac, ip, hostname, vendor) )
+
+#-------------------------------------------------------------------------------
+def read_mikrotik_leases ():
+
+    sql_create_table = """ CREATE TABLE IF NOT EXISTS Mikrotik_Network(
+                                "MT_MAC" STRING(50) NOT NULL COLLATE NOCASE,
+                                "MT_IP" STRING(50) COLLATE NOCASE,
+                                "MT_Name" STRING(50),
+                                "MT_Vendor" STRING(250)
+                            ); """
+    sql.execute(sql_create_table)
+    sql_connection.commit()
+
+    sql.execute ("DELETE FROM Mikrotik_Network")
+
+    if not MIKROTIK_ACTIVE:
+        return
+
+    #installed using pip3 install routeros_api
+    import routeros_api
+
+    data = []
+    conn = routeros_api.RouterOsApiPool(MIKROTIK_IP, MIKROTIK_USER, MIKROTIK_PASS, plaintext_login=True)
+    api = conn.get_api()
+    ret = api.get_resource('/ip/dhcp-server/lease').get()
+    conn.disconnect()
+    #{'id': '*3', 'address': '10.0.0.41', 'mac-address': '7C:2F:80:A4:A4:BF', 'address-lists': '', 'dhcp-option': '', 'status': 'waiting', 'last-seen': '185w22h27m2s', 'host-name': 'C530-IP', 'radius': 'false', 'dynamic': 'false', 'blocked': 'false', 'disabled': 'false', 'comment': 'Gigaset C530-IP'}
+    #{'id': '*16', 'address': '10.0.0.26', 'mac-address': '3C:33:00:48:43:59', 'client-id': '1:3c:33:0:48:43:59', 'address-lists': '', 'dhcp-option': '', 'status': 'bound', 'expires-after': '5m43s', 'last-seen': '4m17s', 'active-address': '10.0.0.26', 'active-mac-address': '3C:33:00:48:43:59', 'active-client-id': '1:3c:33:0:48:43:59', 'active-server': 'dhcp1', 'radius': 'false', 'dynamic': 'false', 'blocked': 'false', 'disabled': 'false', 'comment': ' int.kmera  escam   QF002'}
+    for row in ret:
+        if 'active-mac-address' in row:
+            mac = row['active-mac-address'].lower()
+            ip = row['active-address']
+            hostname = row.get('host-name','')
+            try:
+                vendor = MacLookup().lookup(mac)
+            except:
+                vendor = "Prefix is not registered"
+
+            sql.execute ("INSERT INTO Mikrotik_Network (MT_MAC, MT_IP, MT_Name, MT_Vendor) "+
+                         "VALUES (?, ?, ?, ?) ", (mac, ip, hostname, vendor) )
+
+#-------------------------------------------------------------------------------
+def read_unifi_clients ():
+
+    sql_create_table = """ CREATE TABLE IF NOT EXISTS Unifi_Network(
+                                "UF_MAC" STRING(50) NOT NULL COLLATE NOCASE,
+                                "UF_IP" STRING(50) COLLATE NOCASE,
+                                "UF_Name" STRING(50),
+                                "UF_Vendor" STRING(250)
+                            ); """
+    sql.execute(sql_create_table)
+    sql_connection.commit()
+
+    sql.execute ("DELETE FROM Unifi_Network")
+
+    if not UNIFI_ACTIVE:
+        return
+
+    #installed using pip3 install unifi
+    from pyunifi.controller import Controller
+
+    data = []
+    c = Controller(UNIFI_IP,UNIFI_USER,UNIFI_PASS,8443,'v5','default',ssl_verify=False)
+    clients = c.get_clients()
+    for row in clients:
+        mac = row['mac'].lower()
+        ip = row.get('ip','no IP')
+        hostname = row.get('hostname',row.get('name',''))
+        vendor = row.get('oui',None)
+        if not vendor:
+            try:
+                vendor = MacLookup().lookup(mac)
+            except:
+                vendor = "Prefix is not registered"
+
+        sql.execute ("INSERT INTO Unifi_Network (UF_MAC, UF_IP, UF_Name, UF_Vendor) "+
+                     "VALUES (?, ?, ?, ?) ", (mac, ip, hostname, vendor) )
 
 #-------------------------------------------------------------------------------
 def read_DHCP_leases ():
@@ -739,6 +827,24 @@ def save_scanned_devices (p_arpscan_devices, p_cycle_interval):
                                       WHERE cur_MAC = FB_MAC )""",
                     (cycle) )
 
+    # Insert Mikrotik devices
+    sql.execute ("""INSERT INTO CurrentScan (cur_ScanCycle, cur_MAC, 
+                        cur_IP, cur_Vendor, cur_ScanMethod)
+                    SELECT ?, MT_MAC, MT_IP, MT_Vendor, 'Mikrotik'
+                    FROM Mikrotik_Network
+                    WHERE NOT EXISTS (SELECT 'X' FROM CurrentScan
+                                      WHERE cur_MAC = MT_MAC )""",
+                    (cycle) )
+
+    # Insert UniFi devices
+    sql.execute ("""INSERT INTO CurrentScan (cur_ScanCycle, cur_MAC, 
+                        cur_IP, cur_Vendor, cur_ScanMethod)
+                    SELECT ?, UF_MAC, UF_IP, UF_Vendor, 'UniFi'
+                    FROM Unifi_Network
+                    WHERE NOT EXISTS (SELECT 'X' FROM CurrentScan
+                                      WHERE cur_MAC = UF_MAC )""",
+                    (cycle) )
+
     # Check Internet connectivity
     internet_IP = get_internet_IP()
         # TESTING - Force IP
@@ -775,6 +881,10 @@ def remove_entries_from_table():
         sql.execute(query)
         query = 'DELETE FROM Fritzbox_Network WHERE FB_MAC IN ({})'.format(mac_addresses)
         sql.execute(query)
+        query = 'DELETE FROM Mikrotik_Network WHERE MT_MAC IN ({})'.format(mac_addresses)
+        sql.execute(query)
+        query = 'DELETE FROM Unifi_Network WHERE UF_MAC IN ({})'.format(mac_addresses)
+        sql.execute(query)
     except NameError:
         print("        No ignore list defined")
 
@@ -800,6 +910,16 @@ def print_scan_stats ():
                     WHERE cur_ScanMethod='Fritzbox' AND cur_ScanCycle = ? """,
                     (cycle,))
     print ('        Fritzbox Method....: +' + str (sql.fetchone()[0]) )
+    # Devices Mikrotik
+    sql.execute ("""SELECT COUNT(*) FROM CurrentScan
+                    WHERE cur_ScanMethod='Mikrotik' AND cur_ScanCycle = ? """,
+                    (cycle,))
+    print ('        Mikrotik Method....: +' + str (sql.fetchone()[0]) )
+    # Devices UniFi
+    sql.execute ("""SELECT COUNT(*) FROM CurrentScan
+                    WHERE cur_ScanMethod='UniFi' AND cur_ScanCycle = ? """,
+                    (cycle,))
+    print ('        UniFi Method....: +' + str (sql.fetchone()[0]) )
     # New Devices
     sql.execute ("""SELECT COUNT(*) FROM CurrentScan
                     WHERE cur_ScanCycle = ? 
@@ -1076,6 +1196,30 @@ def update_devices_data_from_scan ():
                            OR dev_Name IS NULL)
                       AND EXISTS (SELECT 1 FROM DHCP_Leases
                                   WHERE DHCP_MAC = dev_MAC)""")
+
+    # Mikrotik Leases - Update (unknown) Name
+    sql.execute ("""UPDATE Devices
+                    SET dev_Name = (SELECT MT_Name FROM Mikrotik_Network
+                                    WHERE MT_MAC = dev_MAC)
+                    WHERE (dev_Name = "(unknown)"
+                           OR dev_Name = ""
+                           OR dev_Name IS NULL)
+                      AND EXISTS (SELECT 1 FROM Mikrotik_Network
+                                  WHERE MT_MAC = dev_MAC
+                                    AND MT_NAME IS NOT NULL
+                                    AND MT_NAME <> '') """)
+
+    # Unifi Leases - Update (unknown) Name
+    sql.execute ("""UPDATE Devices
+                    SET dev_Name = (SELECT UF_Name FROM Unifi_Network
+                                    WHERE UF_MAC = dev_MAC)
+                    WHERE (dev_Name = "(unknown)"
+                           OR dev_Name = ""
+                           OR dev_Name IS NULL)
+                      AND EXISTS (SELECT 1 FROM Unifi_Network
+                                  WHERE UF_MAC = dev_MAC
+                                    AND UF_Name IS NOT NULL
+                                    AND UF_Name <> '') """)
 
     # DHCP Leases - Vendor
     print_log ('Update devices - 5 Vendor')

--- a/back/pialert.py
+++ b/back/pialert.py
@@ -720,8 +720,6 @@ def read_mikrotik_leases ():
     api = conn.get_api()
     ret = api.get_resource('/ip/dhcp-server/lease').get()
     conn.disconnect()
-    #{'id': '*3', 'address': '10.0.0.41', 'mac-address': '7C:2F:80:A4:A4:BF', 'address-lists': '', 'dhcp-option': '', 'status': 'waiting', 'last-seen': '185w22h27m2s', 'host-name': 'C530-IP', 'radius': 'false', 'dynamic': 'false', 'blocked': 'false', 'disabled': 'false', 'comment': 'Gigaset C530-IP'}
-    #{'id': '*16', 'address': '10.0.0.26', 'mac-address': '3C:33:00:48:43:59', 'client-id': '1:3c:33:0:48:43:59', 'address-lists': '', 'dhcp-option': '', 'status': 'bound', 'expires-after': '5m43s', 'last-seen': '4m17s', 'active-address': '10.0.0.26', 'active-mac-address': '3C:33:00:48:43:59', 'active-client-id': '1:3c:33:0:48:43:59', 'active-server': 'dhcp1', 'radius': 'false', 'dynamic': 'false', 'blocked': 'false', 'disabled': 'false', 'comment': ' int.kmera  escam   QF002'}
     for row in ret:
         if 'active-mac-address' in row:
             mac = row['active-mac-address'].lower()

--- a/config/pialert.conf
+++ b/config/pialert.conf
@@ -121,3 +121,18 @@ FRITZBOX_PASS     = 'password'
 # ----------------------
 DAYS_TO_KEEP_ONLINEHISTORY = 30
 DAYS_TO_KEEP_EVENTS = 90
+
+# Mikrotik Configuration
+# ----------------------
+MIKROTIK_ACTIVE = False
+MIKROTIK_IP     = '10.0.0.1'
+MIKROTIK_USER   = 'user'
+MIKROTIK_PASS   = 'password'
+
+# UniFi Configuration
+# -------------------
+UNIFI_ACTIVE = False
+UNIFI_IP     = '10.0.0.2'
+UNIFI_USER   = 'user'
+UNIFI_PASS   = 'password'
+

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -16,7 +16,7 @@ Estimated time: 20'
 
 ## One-step Automated Install:
 <!--- --------------------------------------------------------------------- --->
-  #### `curl -sSL https://github.com/leiweibau/Pi.Alert/raw/main/install/pialert_install.sh | bash`
+  #### `curl -sSL https://github.com/piapiacz/Pi.Alert/raw/main/install/pialert_install.sh | bash`
 
 ## Uninstall process
 <!--- --------------------------------------------------------------------- --->
@@ -211,13 +211,15 @@ block is not necessary
   ```
   pip3 install mac-vendor-lookup
   pip3 install fritzconnection
+  pip3 install routeros_api
+  pip3 install unifi
   ```
 
 ### Pi.Alert
 <!--- --------------------------------------------------------------------- --->
 5.1 - Download Pi.Alert and uncompress
   ```
-curl -sL https://github.com/leiweibau/Pi.Alert/raw/main/tar/pialert_latest.tar | tar xf - -C $HOME
+curl -sL https://github.com/piapiacz/Pi.Alert/raw/main/tar/pialert_latest.tar | tar xf - -C $HOME
   ```
 
 5.2 - Public the front portal

--- a/install/pialert_install.sh
+++ b/install/pialert_install.sh
@@ -394,9 +394,13 @@ install_python() {
     if [ -f /usr/lib/python3.*/EXTERNALLY-MANAGED ]; then
       pip3 -q install mac-vendor-lookup --break-system-packages                                 2>&1 >> "$LOG"
       pip3 -q install fritzconnection --break-system-packages                                   2>&1 >> "$LOG"
+      pip3 -q install routeros_api --break-system-packages                                      2>&1 >> "$LOG"
+      pip3 -q install unifi --break-system-packages                                             2>&1 >> "$LOG"
     else
       pip3 -q install mac-vendor-lookup                                                         2>&1 >> "$LOG"
       pip3 -q install fritzconnection                                                           2>&1 >> "$LOG"
+      pip3 -q install routeros_api                                                              2>&1 >> "$LOG"
+      pip3 -q install unifi                                                                     2>&1 >> "$LOG"
     fi
 
     PYTHON_BIN="python3"


### PR DESCRIPTION
Here is added support for reading DHCP leases from Mikrotik router and reading clients from Unifi controller.
I also moved import "FritzHosts" from beginning of the "pialert.py" file to the "read_fritzbox_active_hosts" function. So it wouldn't be imported if FRITZBOX_ACTIVE is not enabled.
I also altered the readme and install files to reflect the required python modules ("routeros_api" for Mikrotik and "pyunifi" for Unifi)