### PR TITLE
fixed arp-scan dectection

### DIFF
--- a/front/php/server/devices.php
+++ b/front/php/server/devices.php
@@ -89,7 +89,7 @@ if (isset($_REQUEST['action']) && !empty($_REQUEST['action'])) {
 	}
 }
 function GetARPStatus() {
-	$execstring = 'ps -aux | grep "/pialert/back/pialert.py 1" | grep -v grep | sed \'/>~\/pialert\/log\/pialert.1.log/d\'';
+	$execstring = 'ps -aux | grep "/pialert/back/pialert.py 1" | grep -v grep | grep -v "/pialert/log/pialert.1.log"';
 	$pia_arpscans = "";
 	exec($execstring, $pia_arpscans);
 	$result = array(sizeof($pia_arpscans));


### PR DESCRIPTION
The fix is necessary because there are 2 different variants (~/path or $HOME/path) of the command