### PR TITLE
:bug: Fix "Undefined variable $report_counter"

### DIFF
--- a/front/php/server/files.php
+++ b/front/php/server/files.php
@@ -870,7 +870,6 @@ function deleteAllNotifications() {
 function getReportTotals() {
 	$files = array_diff(scandir('../../reports'), array('..', '.', 'download_report.php'));
 	$report_counter = count($files);
-	if ($report_counter == 0) {unset($report_counter);}
 
 	$totals = array($report_counter);
 	echo (json_encode($totals));


### PR DESCRIPTION
I didn't quite understand why the variable $report_counter is unset. If this is important, feel free to correct my change.