### PR TITLE
Next update

### DIFF
--- a/install/pialert_update.sh
+++ b/install/pialert_update.sh
@@ -59,7 +59,7 @@ main() {
   print_header "Update process finished"
   if $PIHOLE_MOVED ; then
     print_msg ""
-    print_msg "!! Pi-hole Webinterface moved from Port 80 to Port 8080 !!"
+    print_header "!! Pi-hole Webinterface moved from Port 80 to Port 8080 !!"
   fi
   print_msg ""
 
@@ -125,13 +125,13 @@ check_pihole() {
         CORE_VERSION=$(echo "$VERSION_OUTPUT" | grep -oP 'Core version is v\K[0-9]+')
 
         if [[ $CORE_VERSION -ge 6 ]]; then
-            echo "Pi-hole 6.x detected. Webinterface moved to Port 8080..."
+            print_header "Pi-hole 6.x detected. Webinterface moved to Port 8080..."
             sudo systemctl stop lighttpd
             sudo systemctl start lighttpd
             sudo pihole-FTL --config webserver.port 8080o,[::]:8080o,443so,[::]:443so
             sudo systemctl restart pihole-FTL
             sudo systemctl start lighttpd
-            echo "Pi-hole Configuration applied"
+            #echo "Pi-hole Configuration applied"
             PIHOLE_MOVED=true
         fi
     fi

--- a/install/pialert_update.sh
+++ b/install/pialert_update.sh
@@ -20,6 +20,7 @@ fi
 PIALERT_HOME="$INSTALL_DIR/pialert"
 LOG="pialert_update_`date +"%Y-%m-%d_%H-%M"`.log"
 PYTHON_BIN=python3
+PIHOLE_MOVED=false
 
 
 # ------------------------------------------------------------------------------
@@ -56,6 +57,10 @@ main() {
   test_pialert
   
   print_header "Update process finished"
+  if $PIHOLE_MOVED ; then
+    print_msg ""
+    print_msg "!! Pi-hole Webinterface moved from Port 80 to Port 8080 !!"
+  fi
   print_msg ""
 
   move_logfile
@@ -120,13 +125,14 @@ check_pihole() {
         CORE_VERSION=$(echo "$VERSION_OUTPUT" | grep -oP 'Core version is v\K[0-9]+')
 
         if [[ $CORE_VERSION -ge 6 ]]; then
-            echo "Pi-hole detected. Webinterface moved to Port 8080..."
+            echo "Pi-hole 6.x detected. Webinterface moved to Port 8080..."
             sudo systemctl stop lighttpd
             sudo systemctl start lighttpd
             sudo pihole-FTL --config webserver.port 8080o,[::]:8080o,443so,[::]:443so
             sudo systemctl restart pihole-FTL
             sudo systemctl start lighttpd
             echo "Pi-hole Configuration applied"
+            PIHOLE_MOVED=true
         fi
     fi
 

--- a/install/pialert_update.sh
+++ b/install/pialert_update.sh
@@ -127,9 +127,9 @@ check_pihole() {
         if [[ $CORE_VERSION -ge 6 ]]; then
             print_header "Pi-hole 6.x detected. Webinterface moved to Port 8080..."
             sudo systemctl stop lighttpd
-            sudo systemctl start lighttpd
             sudo pihole-FTL --config webserver.port 8080o,[::]:8080o,443so,[::]:443so
             sudo systemctl restart pihole-FTL
+            sudo systemctl enable lighttpd
             sudo systemctl start lighttpd
             #echo "Pi-hole Configuration applied"
             PIHOLE_MOVED=true


### PR DESCRIPTION
The update script now also checks whether Pihole 6 has been installed and configures the Pihole web interface to the alternative port 8080. It then reactivates “lighttpd” and starts the service.
What it does not do: It does not check whether these steps are necessary. It simply does it as soon as a Pihole 6 installation is detected.