### PR TITLE
Add support for multiple DHCP servers

### DIFF
--- a/back/pialert.py
+++ b/back/pialert.py
@@ -2638,9 +2638,11 @@ def rogue_dhcp_notification():
     if len(rows) == 1:
         print('    No DHCP Server detected.')
 
+    valid_dhcp_server_list = [DHCP_SERVER_ADDRESS] if not type(DHCP_SERVER_ADDRESS) is list else DHCP_SERVER_ADDRESS
+
     if len(rows) == 2:
         if validate_dhcp_address(rows[1][0]):
-            if rows[1][0] == DHCP_SERVER_ADDRESS :
+            if rows[1][0] in valid_dhcp_server_list :
                 print('    One DHCP Server detected......: ' + rows[1][0] + ' (valid)')
             else:
                 print('    One DHCP Server detected......: ' + rows[1][0] + ' (invalid)')
@@ -2652,7 +2654,7 @@ def rogue_dhcp_notification():
         print('    Multiple DHCP Servers detected:')
         for i in range(1,len(rows),1):
             if validate_dhcp_address(rows[i][0]):
-                if rows[i][0] == DHCP_SERVER_ADDRESS :
+                if rows[i][0] in valid_dhcp_server_list :
                     print('        ' + rows[i][0] + ' (valid)' )
                 else:
                     print('        ' + rows[i][0] + ' (rogue)' )

--- a/docs/PIALERT_CONF.md
+++ b/docs/PIALERT_CONF.md
@@ -39,7 +39,7 @@ I would like to give a short explanation to the individual points.
 | Option               | Description |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | SCAN_ROGUE_DHCP     | Activates the search for foreign, also called "rogue", DHCP servers. This function is used to detect whether there is a foreign DHCP server in the network that could take control of IP management. |
-| DHCP_SERVER_ADDRESS | The IP of the known DHCP server is stored here. Only ONE DHCP server can be entered.                                                                                                                 |
+| DHCP_SERVER_ADDRESS | The IP of the known DHCP server is stored here. A list of DHCP servers is also supported                                                                                                                 |
 
 
 #### Custom Cronjobs

--- a/front/php/server/files.php
+++ b/front/php/server/files.php
@@ -181,6 +181,7 @@ function SaveConfigFile() {
 	$ignorlist_search = array("[ ", " ]", ", ", ",", "[", "]");
 	$ignorlist_replace = array("[", "]", ",", "','", "['", "']");
 	// Handle some special entries
+	$configArray['DHCP_SERVER_ADDRESS'] = str_replace($ignorlist_search, $ignorlist_replace, $configArray['DHCP_SERVER_ADDRESS']);
 	$Mail_Reort = str_replace(" ", "", $configArray['REPORT_FROM']);
 	if (stristr($Mail_Reort, "<+SMTP_USER+>")) {
 		$mail_parts = array();
@@ -249,6 +250,8 @@ SATELLITES_ACTIVE          = " . convert_bool($configArray['SATELLITES_ACTIVE'])
 # ----------------------
 SCAN_ROGUE_DHCP            = " . convert_bool($configArray['SCAN_ROGUE_DHCP']) . "
 DHCP_SERVER_ADDRESS        = '" . $configArray['DHCP_SERVER_ADDRESS'] . "'
+# DHCP_SERVER_ADDRESS        = '192.168.1.1'
+# DHCP_SERVER_ADDRESS        = ['192.168.1.1', '10.0.0.1']
 
 # Custom Cronjobs
 # ----------------------


### PR DESCRIPTION
This PR adds support to make `DHCP_SERVER_ADDRESS` also valid as an array. This helps detecting rogue DHCP servers in a multi-subnet configuration